### PR TITLE
Added RET_VAL variable to correctly return rc from apt commands

### DIFF
--- a/usr/bin/galliumos-update
+++ b/usr/bin/galliumos-update
@@ -53,7 +53,8 @@ sudo_apt_get() {
   eval "$cmd"
   rc=$?
   /bin/echo -e "${ANSI_RST}\c"
-  [ "$rc" -ne 0 ] && echo_err "\"$cmd\" returned an error. Proceed with caution."
+  [ "$rc" -ne 0 ] && echo_err "\"$cmd\" returned an error. Proceed with caution." && return $rc
+  return 0
 }
 
 hold() {
@@ -68,12 +69,15 @@ hold() {
 if [ "$(id -u)" -eq 0 -o "$(groups | grep -w sudo)" ]; then
   echo_title "Updating package directories..."
   sudo_apt_get -qq update
+  RET_VAL=$?
 
   echo_title "Updating packages..."
   sudo_apt_get dist-upgrade
+  RET_VAL=$(($RET_VAL+$?))
 else
   echo_err "\n$(basename $0): fatal: must be root or in \"sudo\" group."
 fi
 
 [ "$HOLD" ] && hold
 
+exit $RET_VAL


### PR DESCRIPTION
This is aimed at addressing [Issue #474](https://github.com/GalliumOS/galliumos-distro/issues/474) from the main issue tracker. 

Previously, when run from the command line without the `--hold` argument passed, the script would always return 1. `RET_VAL` accumulates the return values from both `apt` commands and then is used as the return value for the script. 