### PR TITLE
Fully transfer script to apt

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,2 @@
+# galliumos-update
+GalliumOS Update script and notifier

--- a/usr/bin/galliumos-update
+++ b/usr/bin/galliumos-update
@@ -45,7 +45,7 @@ echo_cmd()   { /bin/echo -e "${ANSI_CYA}${*}${ANSI_RST}"; }
 echo_err()   { /bin/echo -e "${ANSI_RED}${*}${ANSI_RST}"; }
 echo_title() { /bin/echo -e "\n${ANSI_HI}${ANSI_WHT}${*}${ANSI_RST}"; }
 
-sudo_apt_get() {
+sudo_apt() {
   cmd="sudo apt $*"
   echo_cmd $cmd
 
@@ -67,10 +67,10 @@ hold() {
 
 if [ "$(id -u)" -eq 0 -o "$(groups | grep -w sudo)" ]; then
   echo_title "Updating package directories..."
-  sudo_apt_get -qq update
+  sudo_apt -qq update
 
   echo_title "Updating packages..."
-  sudo_apt_get dist-upgrade
+  sudo_apt full-upgrade
 else
   echo_err "\n$(basename $0): fatal: must be root or in \"sudo\" group."
 fi


### PR DESCRIPTION
Replaced `apt dist-upgrade` with `apt full-upgrade`. No difference except `apt full-upgrade` is the proper command, `apt dist-upgrade` is for compatibility and will be deprecated.

Also added a simple README.md

Love this OS, keep up the good work!